### PR TITLE
Allows dirty package during local registry push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,5 +115,5 @@ jobs:
             using Pkg
             Pkg.add("LocalRegistry")
             using LocalRegistry
-            register(registry="git@github.com:numoptim/NumOptimRegistry.git", push=true)
+            register(registry="git@github.com:numoptim/NumOptimRegistry.git", push=true, allow_package_dirty=true)
           '


### PR DESCRIPTION
This PR updates the ci.yml workflow's release job by allowing for the registry update to be "dirty". The reason for this is that during the build, Manifest.toml gets created yet this is not committed to the branch and it should be ignored. Hence, the result is a "dirty" branch.